### PR TITLE
Feature/use seats

### DIFF
--- a/src/entities/seats/hooks/useSeats/useSeats.test.ts
+++ b/src/entities/seats/hooks/useSeats/useSeats.test.ts
@@ -1,0 +1,40 @@
+import { renderHook } from "@testing-library/react";
+import { seatsMock } from "../../mocks/seatsMock";
+import { SeatsStructure } from "../../types";
+import useSeats from "./useSeats";
+import { wrapWithProviders } from "../../../../utils/testUtils";
+import { server } from "../../../../mocks/node";
+import { errorHandlers } from "../../../../mocks/handlers";
+
+describe("Given a useSeats functions", () => {
+  const sessionId = "1";
+  describe("When it calls the getSeatsBySession function", () => {
+    test("Then it should return a seats information", async () => {
+      const seatsInformation: SeatsStructure = seatsMock;
+
+      const {
+        result: {
+          current: { getSeatsBySession },
+        },
+      } = renderHook(() => useSeats(), { wrapper: wrapWithProviders });
+
+      const expectedSeatsInformation = await getSeatsBySession(sessionId);
+
+      expect(expectedSeatsInformation).toStrictEqual(seatsInformation);
+    });
+  });
+
+  describe("When the getSeatsBySession is called and an error occurs", () => {
+    test("Then it should throw an error", () => {
+      server.resetHandlers(...errorHandlers);
+
+      const {
+        result: {
+          current: { getSeatsBySession },
+        },
+      } = renderHook(() => useSeats(), { wrapper: wrapWithProviders });
+
+      expect(getSeatsBySession(sessionId)).rejects.toThrowError();
+    });
+  });
+});

--- a/src/entities/seats/hooks/useSeats/useSeats.ts
+++ b/src/entities/seats/hooks/useSeats/useSeats.ts
@@ -1,0 +1,28 @@
+import { useCallback } from "react";
+import { SeatsStructure } from "../../types";
+import path from "../../../../routers/paths/paths";
+import axios from "axios";
+import showToast from "../../../../Toast/showToast";
+
+const apiUrl = import.meta.env.VITE_API_URL;
+
+const useSeats = () => {
+  const getSeatsBySession = useCallback(
+    async (id: string): Promise<SeatsStructure> => {
+      try {
+        const { data: seats } = await axios.get<SeatsStructure>(
+          `${apiUrl}${path.seats}/${id}`,
+        );
+        return seats;
+      } catch {
+        const error = "Sorry, can't load seats information now";
+        showToast(error, "error");
+        throw error;
+      }
+    },
+    [],
+  );
+  return { getSeatsBySession };
+};
+
+export default useSeats;

--- a/src/entities/seats/mocks/seatsMock.ts
+++ b/src/entities/seats/mocks/seatsMock.ts
@@ -6,3 +6,10 @@ export const seatsMock: SeatsStructure = {
   sessionId: 1,
   reserved: ["r1s3", "r1s4", "r2s2", "r4s5"],
 };
+
+export const emptySeatsMock: SeatsStructure = {
+  id: 1,
+  movieId: 1,
+  sessionId: 1,
+  reserved: [],
+};

--- a/src/entities/sessions/hooks/useSessions/useSessions.test.ts
+++ b/src/entities/sessions/hooks/useSessions/useSessions.test.ts
@@ -1,6 +1,5 @@
 import { renderHook } from "@testing-library/react";
 import { sessionsMock } from "../../mocks/sessionsMock";
-
 import useSessions from "./useSessions";
 import { wrapWithProviders } from "../../../../utils/testUtils";
 import { SessionsStructure } from "../../types";
@@ -25,7 +24,7 @@ describe("Given a useSessions function", () => {
     });
   });
 
-  describe("When the getSessions function is called and an error occurs", () => {
+  describe("When the getSessionsByMovie function is called and an error occurs", () => {
     test("Then it should throw an error", () => {
       server.resetHandlers(...errorHandlers);
 

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -8,6 +8,7 @@ import {
   emptySessionsMock,
   sessionsMock,
 } from "../entities/sessions/mocks/sessionsMock";
+import { emptySeatsMock, seatsMock } from "../entities/seats/mocks/seatsMock";
 
 const apiUrl = import.meta.env.VITE_API_URL;
 
@@ -23,6 +24,10 @@ export const handlers = [
   http.get(`${apiUrl}${path.sessions}/1`, () => {
     return HttpResponse.json(sessionsMock[0], { status: 200 });
   }),
+
+  http.get(`${apiUrl}${path.seats}/1`, () => {
+    return HttpResponse.json(seatsMock, { status: 200 });
+  }),
 ];
 
 export const errorHandlers = [
@@ -36,5 +41,9 @@ export const errorHandlers = [
 
   http.get(`${apiUrl}${path.sessions}/1`, () => {
     return HttpResponse.json(emptySessionsMock, { status: 401 });
+  }),
+
+  http.get(`${apiUrl}${path.seats}/1`, () => {
+    return HttpResponse.json(emptySeatsMock, { status: 401 });
   }),
 ];


### PR DESCRIPTION
- Creado custom hook `useSeats` con la función `getSeatsBySession`, que trae la información de los asientos reservados desde la api para una sesión concreta (id)
- Creada la suite de test `useSeats.test.ts` para testear casos de uso de la función `getSeatsBySession`
   - Creados handlers y mocks necesarios