### PR TITLE
Feature/axios sessions client

### DIFF
--- a/src/entities/sessions/hooks/useSessions/useSessions.test.ts
+++ b/src/entities/sessions/hooks/useSessions/useSessions.test.ts
@@ -5,9 +5,13 @@ import { wrapWithProviders } from "../../../../utils/testUtils";
 import { SessionsStructure } from "../../types";
 import { server } from "../../../../mocks/node";
 import { errorHandlers } from "../../../../mocks/handlers";
+import AxiosSessionsClient from "../../services/AxiosSessionsClient";
+import apiUrl from "../../../../utils/apiUrl/apiUrl";
 
 describe("Given a useSessions function", () => {
   const movieId = "1";
+  const sessionsClient = new AxiosSessionsClient(apiUrl);
+
   describe("When it calls the getSessionsByMovie function", () => {
     test("Then it should return a session information", async () => {
       const session: SessionsStructure = sessionsMock[0];
@@ -16,7 +20,9 @@ describe("Given a useSessions function", () => {
         result: {
           current: { getSessionsByMovie },
         },
-      } = renderHook(() => useSessions(), { wrapper: wrapWithProviders });
+      } = renderHook(() => useSessions(sessionsClient), {
+        wrapper: wrapWithProviders,
+      });
 
       const expectedSession = await getSessionsByMovie(movieId);
 
@@ -32,7 +38,9 @@ describe("Given a useSessions function", () => {
         result: {
           current: { getSessionsByMovie },
         },
-      } = renderHook(() => useSessions(), { wrapper: wrapWithProviders });
+      } = renderHook(() => useSessions(sessionsClient), {
+        wrapper: wrapWithProviders,
+      });
 
       expect(getSessionsByMovie(movieId)).rejects.toThrowError();
     });

--- a/src/entities/sessions/hooks/useSessions/useSessions.ts
+++ b/src/entities/sessions/hooks/useSessions/useSessions.ts
@@ -1,18 +1,13 @@
 import { useCallback } from "react";
-import axios from "axios";
-import paths from "../../../../routers/paths/paths";
 import { SessionsStructure } from "../../types";
 import showToast from "../../../../toast/showToast";
+import SessionsClient from "../../services/types";
 
-const apiUrl = import.meta.env.VITE_API_URL;
-
-const useSessions = () => {
+const useSessions = (sessionsClient: SessionsClient) => {
   const getSessionsByMovie = useCallback(
     async (movieId: string): Promise<SessionsStructure[]> => {
       try {
-        const { data: session } = await axios.get<SessionsStructure[]>(
-          `${apiUrl}${paths.sessions}?movieId=${movieId}`,
-        );
+        const session = await sessionsClient.getSessionsByMovie(movieId);
 
         return session;
       } catch {
@@ -21,7 +16,7 @@ const useSessions = () => {
         throw error;
       }
     },
-    [],
+    [sessionsClient],
   );
   return { getSessionsByMovie };
 };

--- a/src/entities/sessions/services/AxiosSessionsClient.ts
+++ b/src/entities/sessions/services/AxiosSessionsClient.ts
@@ -1,0 +1,18 @@
+import axios from "axios";
+import { SessionsStructure } from "../types";
+import SessionsClient from "./types";
+import paths from "../../../routers/paths/paths";
+
+class AxiosSessionsClient implements SessionsClient {
+  constructor(private apiUrl: string) {}
+
+  async getSessionsByMovie(movieId: string): Promise<SessionsStructure[]> {
+    const { data: session } = await axios.get<SessionsStructure[]>(
+      `${this.apiUrl}${paths.sessions}?movieId=${movieId}`,
+    );
+
+    return session;
+  }
+}
+
+export default AxiosSessionsClient;

--- a/src/entities/sessions/services/types.ts
+++ b/src/entities/sessions/services/types.ts
@@ -1,0 +1,7 @@
+import { SessionsStructure } from "../types";
+
+interface SessionsClient {
+  getSessionsByMovie(movieId: string): Promise<SessionsStructure[]>;
+}
+
+export default SessionsClient;

--- a/src/pages/MovieDetailPage/MovieDetailPage.tsx
+++ b/src/pages/MovieDetailPage/MovieDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import Button from "../../components/Button/Button";
 import MovieDetailSkeleton from "../../components/Loaders/MovieDetailSkeleton/MovieDetailSkeleton";
 import { useAppDispatch, useAppSelector } from "../../store";
@@ -13,12 +13,16 @@ import useSessions from "../../entities/sessions/hooks/useSessions/useSessions";
 import { loadSessionsActionCreator } from "../../entities/sessions/slice/sessionsSlice";
 import convertDateTime from "../../convertDates/convertDates";
 import paths from "../../routers/paths/paths";
+import AxiosSessionsClient from "../../entities/sessions/services/AxiosSessionsClient";
+import apiUrl from "../../utils/apiUrl/apiUrl";
 
 const MovieDetailPage = (): React.ReactElement => {
+  const sessionsClient = useMemo(() => new AxiosSessionsClient(apiUrl), []);
+
   const { isLoading } = useAppSelector((store) => store.ui);
   const { id } = useParams();
   const { getOneMovie } = useMovies();
-  const { getSessionsByMovie } = useSessions();
+  const { getSessionsByMovie } = useSessions(sessionsClient);
   const dispatch = useAppDispatch();
   const movie = useAppSelector((store) => store.movies.selectedMovie);
   const sessions = useAppSelector((store) => store.sessions.sessionsData);

--- a/src/utils/apiUrl/apiUrl.ts
+++ b/src/utils/apiUrl/apiUrl.ts
@@ -1,0 +1,3 @@
+const apiUrl = import.meta.env.VITE_API_URL;
+
+export default apiUrl;


### PR DESCRIPTION
- Añadido los `types` de `SessionsClient` con el método `getSessionsByMovie`
- Creada la clase `AxiosSessionsClient` que implementa la interfaz `SessionsClient` con:
  - El constructor que toma un parámetro `apiUrl` y se asigna como propiedad privada de la clase
  - El método `getSessionsByMovie` que se encargará de hacer la request mediante la librería `axios`

- Instanciada la clase `AxiosSessionsClient` en `useSessions` requerida en el test
- Eliminada la `request` directa mediante `axios` de la función `getSessionsByMovie` del *hook* `useSessions` e implementado el método homónimo de la clase `AxiosSessionsClient` que será pedida mediante *paràmetros* al llamar a este *hook*
- Abstraída la variable `apiUrl` a un documento individual dentro de la carpeta homónima dentro de la carpeta `utils`
- Instanciada la clase `AxiosSessionsClient` en el componente `MovieDetailPage` donde se ha usado el *hook* de react `useMemo` para evitar un bucle de llamadas a la `api`.