### PR TITLE
Add sessionsClient at SeatsPage to prevent problems at refreshing

### DIFF
--- a/src/components/SeatsContainer/SeatsContainer.tsx
+++ b/src/components/SeatsContainer/SeatsContainer.tsx
@@ -15,6 +15,7 @@ const SeatsContainer = (): React.ReactElement => {
   const [selectedSession, setSelectedSession] = useState<
     SessionsStructure | undefined | null
   >(null);
+
   const doesSelectedSessionExist = (
     selectedSession: SessionsStructure | undefined | null,
   ) => typeof selectedSession === "undefined";
@@ -31,8 +32,7 @@ const SeatsContainer = (): React.ReactElement => {
     );
 
     if (doesSelectedSessionExist(selectedSession)) {
-      const errorMessage = "Can't load selected session!";
-      showToast(errorMessage, "error");
+      return;
     }
   }, [selectedSession, sessionId, sessionsData]);
 

--- a/src/pages/SeatsPage/SeatsPage.tsx
+++ b/src/pages/SeatsPage/SeatsPage.tsx
@@ -9,13 +9,18 @@ import useMovies from "../../entities/movies/hooks/useMovies";
 import { loadMovieByIdActionCreator } from "../../entities/movies/slice/moviesSlice";
 import AxiosMoviesClient from "../../entities/movies/services/AxiosMoviesClient";
 import apiUrl from "../../utils/apiUrl/apiUrl";
+import AxiosSessionsClient from "../../entities/sessions/services/AxiosSessionsClient";
+import useSessions from "../../entities/sessions/hooks/useSessions/useSessions";
+import { loadSessionsActionCreator } from "../../entities/sessions/slice/sessionsSlice";
 
 const SeatsPage = (): React.ReactElement => {
   const moviesClient = useMemo(() => new AxiosMoviesClient(apiUrl), []);
+  const sessionsClient = useMemo(() => new AxiosSessionsClient(apiUrl), []);
 
   const { movieId, sessionId } = useParams();
   const { getSeatsBySession } = useSeats();
   const { getOneMovie } = useMovies(moviesClient);
+  const { getSessionsByMovie } = useSessions(sessionsClient);
   const dispatch = useAppDispatch();
 
   useEffect(() => {
@@ -23,14 +28,26 @@ const SeatsPage = (): React.ReactElement => {
       scrollTo(0, 0);
 
       if (movieId && sessionId) {
-        const selectedSession = await getSeatsBySession(movieId, sessionId);
+        const selectedSeatsSession = await getSeatsBySession(
+          movieId,
+          sessionId,
+        );
+        const selectedSessions = await getSessionsByMovie(movieId);
         const selectedMovie = await getOneMovie(movieId);
 
-        dispatch(loadSeatsBySessionActionCreator(selectedSession));
+        dispatch(loadSeatsBySessionActionCreator(selectedSeatsSession));
+        dispatch(loadSessionsActionCreator(selectedSessions));
         dispatch(loadMovieByIdActionCreator(selectedMovie));
       }
     })();
-  }, [dispatch, getSeatsBySession, getOneMovie, movieId, sessionId]);
+  }, [
+    dispatch,
+    getSeatsBySession,
+    getOneMovie,
+    movieId,
+    sessionId,
+    getSessionsByMovie,
+  ]);
 
   return (
     <SeatsPageStyled>


### PR DESCRIPTION
- Instanciado el cliente `sessionsClient` y llamado al *hook* `useSessions` para hacer una llamada a la *api* a través de su función `getSessionsByMovie` en la página `SeatsPage`:
  - Esto evita problemas de renderizado al hacer *refresh* en la página y mantener los datos ya que el propio componente no hace llamada a la api y no se guarda la información en su `slice` correspondiente. De esta manera, se mantiene la persistencia
- Eliminada la *función* `showToast` de la linia 35 del componente `seatsContainer` ya que `react` ejecuta esas líneas antes de que la información llegue correctamente al hacer el *refresh*:
  - Se mantiene el `if guard` por si el valor resuelve a undefined 