### PR TITLE
Feature/update seats function

### DIFF
--- a/src/entities/seats/hooks/useSeats/useSeats.test.ts
+++ b/src/entities/seats/hooks/useSeats/useSeats.test.ts
@@ -44,4 +44,39 @@ describe("Given a useSeats functions", () => {
       ).rejects.toThrowError();
     });
   });
+
+  describe("When the updateSeat function is called with an id and the updated seats information", () => {
+    test("Then it should return the updated seats information", async () => {
+      const updatedSeats: SeatsStructure = seatsMock;
+
+      const {
+        result: {
+          current: { updateSeat },
+        },
+      } = renderHook(() => useSeats(), { wrapper: wrapWithProviders });
+
+      const expectedSeatsInformation = await updateSeat(
+        seatsMock.movieId.toString(),
+        seatsMock,
+      );
+
+      expect(expectedSeatsInformation).toStrictEqual(updatedSeats);
+    });
+  });
+
+  describe("When the updateSeat function is called with an id and the updated seats information and an error occurs", () => {
+    test("Then it should throw an error", () => {
+      server.resetHandlers(...errorHandlers);
+
+      const {
+        result: {
+          current: { updateSeat },
+        },
+      } = renderHook(() => useSeats(), { wrapper: wrapWithProviders });
+
+      expect(
+        updateSeat(seatsMock.movieId.toString(), seatsMock),
+      ).rejects.toThrowError();
+    });
+  });
 });

--- a/src/entities/seats/hooks/useSeats/useSeats.ts
+++ b/src/entities/seats/hooks/useSeats/useSeats.ts
@@ -41,9 +41,7 @@ const useSeats = () => {
     dataSeat: SeatsStructure,
   ): Promise<SeatsStructure> => {
     try {
-      const {
-        data: { updatedSeat },
-      } = await axios.put<{ updatedSeat: SeatsStructure }>(
+      const { data: updatedSeat } = await axios.put<SeatsStructure>(
         `${apiUrl}${paths.seats}/${id}`,
         dataSeat,
       );

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -36,6 +36,10 @@ export const handlers = [
 
     return HttpResponse.json([seatsMock], { status: 200 });
   }),
+
+  http.put(`${apiUrl}${paths.seats}/1`, () => {
+    return HttpResponse.json(seatsMock, { status: 200 });
+  }),
 ];
 
 export const errorHandlers = [
@@ -61,5 +65,9 @@ export const errorHandlers = [
     url.searchParams.set("sessionId", seatsMock.sessionId.toString());
 
     return HttpResponse.json([emptySeatsMock], { status: 401 });
+  }),
+
+  http.put(`${apiUrl}${paths.seats}/1`, () => {
+    return HttpResponse.json({}, { status: 401 });
   }),
 ];


### PR DESCRIPTION
- Cambiado el *tipo* de la entrada y la salida de la resolución de la *promesa* del método `put` en la función `updateSeats` del *hook* `useSeats`:
  - La promesa resuelve a un único *objeto* `seats`
  
- Testeados los dos casos de uso de la función `updateSeats`  