### PR TITLE
Add styles at SeatsInfo component and SeatsPage page

### DIFF
--- a/src/components/SeatsInfo/SeatsInfoStyled.tsx
+++ b/src/components/SeatsInfo/SeatsInfoStyled.tsx
@@ -4,7 +4,7 @@ const SeatsInfoStyled = styled.section`
   display: flex;
   flex-direction: column;
   gap: 18px;
-  margin: -20px;
+  margin: -30px -20px;
   padding: 28px;
   border-radius: 20px 20px 0 0;
   background-color: ${(props) => props.theme.colors.header};

--- a/src/pages/SeatsPage/SeatsPageStyled.ts
+++ b/src/pages/SeatsPage/SeatsPageStyled.ts
@@ -1,6 +1,12 @@
 import styled from "styled-components";
 
 const SeatsPageStyled = styled.main`
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  max-width: 320px;
+  margin: 0 auto;
+
   .title {
     color: ${(props) => props.theme.colors.text};
     font-size: ${(props) => props.theme.fontSize.medium};


### PR DESCRIPTION
- Añadido `margin: -30px` al componente `SeatsInfo` para asegurar que se mantiene en el suelo del *viewport*
- Añadido estilos al contenedor principal  de `SeatsPage` para alinear estéticamente los elementos que este contiene