### PR TITLE
Add resetSessionsState reducer and test at SessionsSlice

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -15,6 +15,7 @@ const Modal = ({ url }: ModalProps): React.ReactElement => {
   const handleOnClose = () => {
     dispatch(hideModalActionCreator());
   };
+
   return (
     <ModalStyled>
       <article className="modal-container">

--- a/src/components/Modal/ModalStyled.ts
+++ b/src/components/Modal/ModalStyled.ts
@@ -16,7 +16,8 @@ const ModalStyled = styled.section`
     background-color: ${(props) => props.theme.colors.background};
     color: ${(props) => props.theme.colors.text};
     width: 280px;
-    height: 300px;
+    height: 330px;
+    padding: 30px;
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/src/components/Navbar/Navbar.test.tsx
+++ b/src/components/Navbar/Navbar.test.tsx
@@ -20,8 +20,6 @@ describe("Given a Navbar component", () => {
 
   describe("When it is rendered and the user is not in the main page", () => {
     test("Then it should show a 'back' button", () => {
-      const selectedMovie = moviesMock[0];
-
       const routes = [
         {
           path: paths.app,
@@ -32,14 +30,14 @@ describe("Given a Navbar component", () => {
           element: <Navbar />,
         },
         {
-          path: `${paths.movies}/${selectedMovie.id}`,
+          path: paths.tickets,
           element: <Navbar />,
         },
       ];
 
       const router = createMemoryRouter(routes);
 
-      router.state.location.pathname = `${paths.movies}/${selectedMovie.id}`;
+      router.state.location.pathname = paths.tickets;
 
       const textImage = "back to page button";
 

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -2,22 +2,20 @@ import { Link, useLocation, useParams } from "react-router-dom";
 import NavbarStyled from "./NavbarStyled";
 import paths from "../../routers/paths/paths";
 import { useMemo } from "react";
-import { useAppSelector } from "../../store";
 import PathStructure from "../../routers/paths/types";
 
 const Navbar = (): React.ReactElement => {
   const { pathname } = useLocation();
   const pathNameLocation = pathname.split("/");
   const { movieSlug, sessionId } = useParams();
-  const { id } = useAppSelector((store) => store.movies.selectedMovie);
 
   const hasBackOption = useMemo(() => {
     return (
       pathname === paths.tickets ||
       pathname === `${paths.seats}/${movieSlug}/${sessionId}` ||
-      pathname === `${paths.movies}/${id}`
+      pathname === `${paths.movies}/${movieSlug}`
     );
-  }, [id, movieSlug, pathname, sessionId]);
+  }, [movieSlug, pathname, sessionId]);
 
   const backToLastPage = (
     path: Partial<keyof PathStructure>,
@@ -48,7 +46,7 @@ const Navbar = (): React.ReactElement => {
             backToLastPage(
               pathNameLocation[1] as keyof PathStructure,
               paths,
-              id.toString(),
+              movieSlug as string,
             ) as string
           }
           className="navbar-container__backtopage-button"

--- a/src/components/SeatsContainer/SeatsContainer.tsx
+++ b/src/components/SeatsContainer/SeatsContainer.tsx
@@ -7,13 +7,22 @@ import SeatsContainerStyled from "./SeatsContainerStyled";
 import showToast from "../../toast/showToast";
 import { useEffect, useState } from "react";
 import { SessionsStructure } from "../../entities/sessions/types";
+import { TicketStructure } from "../../entities/tickets/types";
+import paths from "../../routers/paths/paths";
 
-const SeatsContainer = (): React.ReactElement => {
+interface SeatsContainerProps {
+  onClick: (ticket: TicketStructure) => void;
+}
+
+const SeatsContainer = ({
+  onClick,
+}: SeatsContainerProps): React.ReactElement => {
   const { sessionsData } = useAppSelector((store) => store.sessions);
   const { selectedMovie } = useAppSelector((store) => store.movies);
   const { reserved: unavailableSeats } = useAppSelector(
     (store) => store.seats.seatsData,
   );
+  const { ticketsData } = useAppSelector((store) => store.ticket);
   const { sessionId } = useParams();
   const [selectedSession, setSelectedSession] = useState<
     SessionsStructure | undefined | null
@@ -45,6 +54,19 @@ const SeatsContainer = (): React.ReactElement => {
     });
 
     return getSeatsInformation;
+  };
+
+  const handleOnClick = (): void => {
+    const uniqueId = ticketsData.length + 1;
+
+    onClick({
+      id: uniqueId,
+      movieId: selectedMovie.id,
+      sessionId: selectedSession?.id as number,
+      seats: [...reservedSeats],
+      url: `https://ticketin-api.onrender.com${paths.tickets}/${uniqueId}`,
+      price: currentPrice,
+    });
   };
 
   const doesSelectedSessionExist = (
@@ -83,7 +105,9 @@ const SeatsContainer = (): React.ReactElement => {
             date={convertDateTime(selectedSession.dates)}
             seats={getReservedInformationSeats(reservedSeats)}
             price={currentPrice}
-          />{" "}
+            handleOnClick={handleOnClick}
+            isSelected={!reservedSeats.length}
+          />
         </>
       )}
     </SeatsContainerStyled>

--- a/src/components/SeatsInfo/SeatsInfo.test.tsx
+++ b/src/components/SeatsInfo/SeatsInfo.test.tsx
@@ -16,6 +16,8 @@ describe("Given a SeatsInfo component", () => {
             seats={[]}
             price={0}
             date={convertDateTime(sessionsMock[0].dates)}
+            handleOnClick={() => ""}
+            isSelected={false}
           />,
         ),
       );

--- a/src/components/SeatsInfo/SeatsInfo.tsx
+++ b/src/components/SeatsInfo/SeatsInfo.tsx
@@ -1,4 +1,5 @@
 import { DateTimeStructure } from "../../convertDates/convertDates";
+import Button from "../Button/Button";
 import SeatsInfoStyled from "./SeatsInfoStyled";
 
 interface SeatsInfoProps {
@@ -6,6 +7,8 @@ interface SeatsInfoProps {
   date: DateTimeStructure;
   seats: string[];
   price: number;
+  handleOnClick: () => void;
+  isSelected: boolean;
 }
 
 const SeatsInfo = ({
@@ -13,6 +16,8 @@ const SeatsInfo = ({
   date,
   seats,
   price,
+  handleOnClick,
+  isSelected,
 }: SeatsInfoProps): React.ReactElement => {
   return (
     <SeatsInfoStyled className="info-container">
@@ -42,6 +47,14 @@ const SeatsInfo = ({
           <span>Total: {price}€</span>
         </div>
       </article>
+      <div className="buy-container">
+        <Button
+          classname="buy-container__button"
+          text="BUY"
+          actionOnClick={handleOnClick}
+          disabled={isSelected}
+        />
+      </div>
     </SeatsInfoStyled>
   );
 };

--- a/src/components/SeatsInfo/SeatsInfoStyled.tsx
+++ b/src/components/SeatsInfo/SeatsInfoStyled.tsx
@@ -30,6 +30,28 @@ const SeatsInfoStyled = styled.section`
       gap: 10px;
     }
   }
+
+  .buy-container {
+    display: flex;
+    justify-content: center;
+
+    &__button {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      width: 130px;
+      height: 48px;
+      background-color: #2c2c2c;
+      border-radius: 7px;
+      color: ${(props) => props.theme.colors.text};
+      font-size: ${(props) => props.theme.fontSize.medium};
+      font-weight: ${(props) => props.theme.fontWeight.regular};
+
+      &:hover {
+        background-color: ${(props) => props.theme.colors.hover};
+      }
+    }
+  }
 `;
 
 export default SeatsInfoStyled;

--- a/src/entities/sessions/slice/__tests__/resetSessionsState.test.ts
+++ b/src/entities/sessions/slice/__tests__/resetSessionsState.test.ts
@@ -1,0 +1,30 @@
+import { sessionsMock } from "../../mocks/sessionsMock";
+import { SessionsState, SessionsStructure } from "../../types";
+import {
+  resetSessionsStateActionCreator,
+  sessionsReducer,
+} from "../sessionsSlice";
+
+describe("Given a resetSessionsState reducer", () => {
+  describe("When it is called", () => {
+    test("Then it should return an empty list of sessions", () => {
+      const currentEmptyState: SessionsStructure[] = [];
+
+      const currentSessionsState: SessionsState = {
+        sessionsData: sessionsMock,
+      };
+      const resetSessionsState = resetSessionsStateActionCreator();
+
+      const expectedNewSessionsState: SessionsState = {
+        sessionsData: currentEmptyState,
+      };
+
+      const newState: SessionsState = sessionsReducer(
+        currentSessionsState,
+        resetSessionsState,
+      );
+
+      expect(expectedNewSessionsState).toStrictEqual(newState);
+    });
+  });
+});

--- a/src/entities/sessions/slice/sessionsSlice.ts
+++ b/src/entities/sessions/slice/sessionsSlice.ts
@@ -16,10 +16,13 @@ export const sessionsSlice = createSlice({
       ...currentSessionsState,
       sessionsData: action.payload,
     }),
+    resetSessionsState: (): SessionsState => initialSessionsState,
   },
 });
 
-export const { loadSessionsByMovie: loadSessionsActionCreator } =
-  sessionsSlice.actions;
+export const {
+  loadSessionsByMovie: loadSessionsActionCreator,
+  resetSessionsState: resetSessionsStateActionCreator,
+} = sessionsSlice.actions;
 
 export const sessionsReducer = sessionsSlice.reducer;

--- a/src/pages/MovieDetailPage/MovieDetailPage.tsx
+++ b/src/pages/MovieDetailPage/MovieDetailPage.tsx
@@ -10,7 +10,10 @@ import {
 import useMovies from "../../entities/movies/hooks/useMovies";
 import { useNavigate, useParams } from "react-router-dom";
 import useSessions from "../../entities/sessions/hooks/useSessions/useSessions";
-import { loadSessionsActionCreator } from "../../entities/sessions/slice/sessionsSlice";
+import {
+  loadSessionsActionCreator,
+  resetSessionsStateActionCreator,
+} from "../../entities/sessions/slice/sessionsSlice";
 import convertDateTime from "../../convertDates/convertDates";
 import paths from "../../routers/paths/paths";
 import AxiosSessionsClient from "../../entities/sessions/services/AxiosSessionsClient";
@@ -46,6 +49,7 @@ const MovieDetailPage = (): React.ReactElement => {
 
     return () => {
       dispatch(resetMoviesStoreActionCreator());
+      dispatch(resetSessionsStateActionCreator());
     };
   }, [dispatch, getOneMovie, getSessionsByMovie, movieSlug]);
 

--- a/src/routers/appRouter.tsx
+++ b/src/routers/appRouter.tsx
@@ -43,7 +43,7 @@ const appRouter = createBrowserRouter([
         ),
       },
       {
-        path: `${paths.seats}${paths.movieId}${paths.sessionId}`,
+        path: `${paths.seats}${paths.detail}${paths.sessionId}`,
         element: (
           <Suspense>
             <LazySeatsPage />


### PR DESCRIPTION
- Añadido  el reducer `resetSessionsState` en el *slice* `SessionsSlice`
- Testeado el reducer `resetSessionsState`
- Creada la función `handleOnSubmit` en `SeatsPage` pasado por props a `SeatsContainer`:
  - Al ser invocada llama a los *hooks* `updateSeats` y `createTickets` para crear el ticket y actualizar el estado de las sillas reservadas.
  - Dispachea a los *slices* `TicketSlice` y `ModalSlice` para cargar el ticket creado y cambiar el estado del *modal* para hacerlo visible. 
  - En la *función limpiadora* del `useEffect` estos estados se resetean al *estado inicial* 